### PR TITLE
[writing-assist]: Fix text duplication in generated content

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,6 +15,43 @@ export default function Home() {
   const [startGenerating, setStartGenerating] = useState(false);
   const [isMounted, setIsMounted] = useState(false);
 
+  // Helper function to remove duplicated text from the beginning of the response.
+  // The LLM sometimes repeats part of the input text despite instructions not to.
+  // This function detects overlapping text between the end of the current content
+  // and the beginning of the response, then removes the duplicate.
+  const removeDuplicatedPrefix = useCallback(
+    (currentText: string, responseText: string): string => {
+      if (!currentText || !responseText) return responseText;
+
+      // Strip HTML tags for comparison
+      const stripHtml = (html: string) =>
+        html.replace(/<[^>]*>/g, "").trim();
+      const cleanCurrent = stripHtml(currentText);
+      const cleanResponse = stripHtml(responseText);
+
+      // Find the longest suffix of currentText that matches a prefix of responseText
+      // Check up to the last 100 characters of the current text
+      const maxOverlapLength = Math.min(100, cleanCurrent.length);
+      let longestOverlap = 0;
+
+      for (let i = 1; i <= maxOverlapLength; i++) {
+        const suffix = cleanCurrent.slice(-i).toLowerCase();
+        const prefix = cleanResponse.slice(0, i).toLowerCase();
+        if (suffix === prefix) {
+          longestOverlap = i;
+        }
+      }
+
+      // If we found an overlap, remove it from the response
+      if (longestOverlap > 0) {
+        return responseText.slice(longestOverlap).trimStart();
+      }
+
+      return responseText;
+    },
+    []
+  );
+
   const generateText = useCallback(
     async (currentWritingState) => {
       if (isGenerating || !currentWritingState) return;
@@ -28,7 +65,12 @@ export default function Home() {
           exaSearchResults,
           currentWritingState
         );
-        setWritingState((prev) => prev + " " + response.text);
+        // Remove any duplicated text from the beginning of the response
+        const cleanedResponse = removeDuplicatedPrefix(
+          currentWritingState,
+          response.text
+        );
+        setWritingState((prev) => prev + " " + cleanedResponse);
       } catch (error) {
         console.error("Error in generateText:", error);
       } finally {
@@ -36,7 +78,7 @@ export default function Home() {
         setStartGenerating(false);
       }
     },
-    [isGenerating]
+    [isGenerating, removeDuplicatedPrefix]
   );
 
   const handleStartTrigger = useCallback(() => {


### PR DESCRIPTION
# Fix text duplication in generated content

## Summary
The Writing Assistant demo was exhibiting a bug where generated text would sometimes duplicate part of the user's input. For example, typing "The history of artificial intelligence began in the" would result in "The history of artificial intelligence began in the **began in the** mid-20th century" - with "began in the" appearing twice.

This happens because the LLM sometimes repeats part of the input text despite the system prompt instructing it not to. This fix adds a `removeDuplicatedPrefix` helper function that:
1. Strips HTML tags from both the current text and response for comparison
2. Finds the longest suffix of the current text that matches a prefix of the response (up to 100 chars, case-insensitive)
3. Removes the overlapping portion from the response before appending

## Review & Testing Checklist for Human
- [ ] **Test the fix end-to-end**: Go to the Writing Assistant demo, type a partial sentence like "The history of AI began in the" and wait for generation. Verify no text duplication occurs.
- [ ] **Test edge cases**: Try inputs that might legitimately have repeated words (e.g., "I said said") to ensure valid content isn't incorrectly trimmed
- [ ] **Verify HTML handling**: Test with content that already has citations/links to ensure the HTML tag stripping doesn't cause issues with the slice offset

### Recommended Test Plan
1. Deploy to preview environment
2. Type several partial sentences and verify generated continuations don't duplicate the ending words
3. Generate multiple continuations in sequence to ensure the fix works across multiple generations

### Notes
- The 100 character limit for overlap detection is somewhat arbitrary but should cover most realistic duplication cases
- Pre-existing lint warnings about React hooks dependencies were not addressed as they're unrelated to this fix
- Requested by: Sol Kim (sol@exa.ai) / @Dynosol
- Devin session: https://app.devin.ai/sessions/0f64be3af0f34d84aac6df16829bb3ed